### PR TITLE
Use unicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT -c ./unicorn_config.rb


### PR DESCRIPTION
Heroku/WEBrickだとなぜか`Thread.current`がリクエスト毎に違うものになってしまって毎回mysqlのconnectionがつくられてた。unicornだと大丈夫そう。

なんでHerokuだけそうなるかはわからず。（OSX、Ubuntuは大丈夫そうだった）
